### PR TITLE
Rename `error` to `err` in documentation

### DIFF
--- a/docs/develop/go/asynchronous-activity-completion.mdx
+++ b/docs/develop/go/asynchronous-activity-completion.mdx
@@ -57,7 +57,7 @@ The following are the parameters of the `CompleteActivity` function:
   of the return value declared by the Activity function.
 - `err`: The error code to return if the Activity terminates with an error.
 
-If `error` is not null, the value of the `result` field is ignored.
+If `err` is not null, the value of the `result` field is ignored.
 
 To fail the Activity, you would do the following:
 


### PR DESCRIPTION
## What does this PR do?

Updated the inline comment to use `err` instead of `error` to align with the consistent naming convention used throughout the codebase. This change improves readability and avoids confusion when referencing the common `err` identifier in Go code.
